### PR TITLE
refactor: Bigboard.php: Call to `urldecode()`

### DIFF
--- a/Controller/Bigboard.php
+++ b/Controller/Bigboard.php
@@ -55,7 +55,7 @@ class Bigboard extends BaseController
     {
         $user = $this->getUser();
         $project_ids = $this->bigboardModel->selectFindAllProjectsById($user['id']);
-        $search = urldecode($this->request->getStringParam('search', $this->userSession->getBigboardSearch()));
+        $search = urldecode($this->request->getStringParam('search', $this->userSession->getBigboardSearch()) ?? '');
         $this->userSession->setBigboardSearch($search);
         $nb_projects = count($project_ids);
 


### PR DESCRIPTION
This PR restructurises the call to `urldecode()` in `Controller/Bigboard.php` to make sure that the string passed as argument is not NULL (passing NULL to non-nullable internal function is [deprecated as of PHP 8.1](https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg)).